### PR TITLE
feat: add pack validation CI workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate
+on:
+  push:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+  pull_request:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+
+jobs:
+  validate:
+    uses: JacobPEvans/.github/.github/workflows/_cribl-pack-validate.yml@main
+    with:
+      pack-type: edge

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,11 +5,16 @@ on:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
   pull_request:
     paths:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate.yml` calling the shared reusable workflow `JacobPEvans/.github/.github/workflows/_cribl-pack-validate.yml@main`
- Configured with `pack-type: edge` for Cribl Edge pack validation
- Triggers on push/PR changes to `default/**`, `data/**`, `package.json`, and `.github/workflows/validate.yml`
- Includes `workflow_dispatch` for manual runs
- Minimal `permissions: {}` block enforcing least-privilege

## Changes

- New file: `.github/workflows/validate.yml`

## Dependency

CI checks will not pass until [JacobPEvans/.github PR #132](https://github.com/JacobPEvans/.github/pull/132) merges — it delivers the `_cribl-pack-validate.yml` reusable workflow to `main`. The PR itself is mergeable once that dependency lands.

## Test Plan

- [x] `validate.yml` exists and calls reusable workflow with correct `pack-type: edge`
- [x] `permissions: {}` satisfies CodeQL least-privilege requirement
- [x] `workflow_dispatch` present for manual trigger
- [ ] Verify CI passes once `.github` PR #132 merges

Closes #9
