### PR TITLE
refactor(ci): extract build-crbl-pack inline run to scripts/ [routine:inspector]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          # Versioned filename for archival
-          tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
-            data default package.json README.md
-          # Fixed filename for latest-download URLs
-          cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"
+        run: bash scripts/build-crbl-pack.sh
 
       - name: Upload to release
         env:

--- a/scripts/build-crbl-pack.sh
+++ b/scripts/build-crbl-pack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Versioned filename for archival
+tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
+  data default package.json README.md
+# Fixed filename for latest-download URLs
+cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"


### PR DESCRIPTION
The Inspector report.

## Rule

`no-scripts` — Inline shell logic in workflow `run:` blocks should live in versioned scripts, not embedded YAML.

## Finding

File: `.github/workflows/release.yml`
Line range: L19-L25 (Build .crbl pack step)
Severity: low (1 violation in 1 file)

The `Build .crbl pack` step contained a 5-line run block (with comments) that triggers the 4+ non-blank lines rule. Extracted to `scripts/build-crbl-pack.sh`.

## Action

Extracted the pack-build logic to `scripts/build-crbl-pack.sh`; replaced the inline run block with `bash scripts/build-crbl-pack.sh`. No semantic change. YAML parse verified clean. Re-scan returns zero violations.

Note: the same pattern (`release.yml` with the same commented build block) exists in `cc-stream-github-copilot-rest-io`, `cc-edge-copilot-otel`, and `cc-edge-gemini-antigravity-io`. Operator may wish to apply the same extraction to those repos after reviewing this PR.

---

## Provenance

- **Generated by:** [The Inspector](https://github.com/JacobPEvans-personal/.github/blob/main/.claude/prompts/inspector.prompt.md) — cloud routine, daily at 06:00 UTC.
- **Triggered:** Today's rotation landed on rule `no-scripts` (day-of-epoch mod 3 = 2).
- **Why this PR/issue:** `JacobPEvans-personal/cc-edge-claude-code-otel` had the largest un-actioned inline run block matching the no-scripts rule across the active-repo scan (1 violation, 5 non-blank lines; repos with open inspector PRs for the same rule were skipped).
- **State:** `inspector-state` gist — tracks per-(repo, rule) cooldowns and content-hash caches.
- **Label:** `cloud-routine`