### PR TITLE
docs(cc-edge-claude-code-otel): add Quick Start section [routine:archivist]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ This Cribl Edge pack collects Claude Code telemetry from 10 sources (9 file moni
 8. **Plugins** — `~/.claude/plugins/installed_plugins.json`
 9. **OpenTelemetry (OTLP)** — Receives metrics and logs from Claude Code's built-in OTEL instrumentation via gRPC on port 4317.
 
+
+## Quick Start
+
+1. **Install the pack** in Cribl Edge via the Pack Browser (search "Claude Code") or upload the `.crbl` directly.
+
+2. **Set `CLAUDE_HOME`** to the home directory of the user running Claude Code, then restart the Cribl Edge service:
+   ```bash
+   # Linux
+   export CLAUDE_HOME=/home/<user>
+   # macOS
+   export CLAUDE_HOME=/Users/<user>
+   ```
+
+3. **Enable OTLP telemetry** in the shell where you run Claude Code:
+   ```bash
+   export CLAUDE_CODE_ENABLE_TELEMETRY=1
+   export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+   export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+   ```
+
+Events appear in Cribl Edge within seconds. See [Setup: Session Logs](#setup-session-logs-file-monitor) and [Setup: OpenTelemetry](#setup-opentelemetry-otlp) for full platform-specific configuration, permissions, and troubleshooting.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
The Archivist README quality fix.

## Gap

Check 3 failed: `missing_quickstart`. The README quality scorer measures six items from <https://www.makeareadme.com/> and <https://github.com/matiassingers/awesome-readme>.

No section titled `## Quick Start`, `## Install`, `## Installation`, `## Getting Started`, or `## Setup` appeared within the first 80 lines. The pack has detailed per-platform setup guides starting at line 87+ but nothing that lets a new user get started in 30 seconds.

## Proposed fix

Added a 3-step `## Quick Start` section at line 18 (after `## Overview`, before `## Architecture`) covering pack install, `CLAUDE_HOME` env var, and OTLP telemetry env vars with cross-references to the detailed platform guides below.

Fixing check 3 also satisfies check 4 (Usage/examples) because the Quick Start section contains code blocks ≥3 lines.

## Other checks

| # | Check | Status |
| --- | --- | --- |
| 1 | Exists | ✓ |
| 2 | Purpose paragraph | ✓ |
| 3 | Quickstart | ✗ → fixed |
| 4 | Usage/examples | ✗ → fixed (Quickstart now contains code block) |
| 5 | License | ✓ |
| 6 | Length (30–400 non-blank lines) | ✓ (397 after fix) |

---

## Provenance

- **Generated by:** [The Archivist](https://github.com/JacobPEvans-personal/.github/blob/main/routines/archivist.prompt.md) — cloud routine, daily at 09:00 UTC, task `readme-quality`.
- **Triggered:** Daily rotation landed on `readme-quality` (day index mod 2 = 0).
- **Why this PR:** `JacobPEvans-personal/cc-edge-claude-code-otel` was the lowest-scoring eligible repo (4/6) sorted by most-recently-pushed, with no active cooldown and no open archivist PR. Score-0 repos blocked by existing open issues; score-2 repo blocked by open PR; score-3 repos on active cooldown.
- **State:** `archivist-state` gist — 14-day cooldown per `(repo, task)`.
- **Label:** `cloud-routine`
